### PR TITLE
Delete original configuration instead of replacing

### DIFF
--- a/TorSharp/Tools/LineByLineConfigurer.cs
+++ b/TorSharp/Tools/LineByLineConfigurer.cs
@@ -62,16 +62,14 @@ namespace Knapcode.TorSharp.Tools
                 {
                     string backupPath = path + ".bak";
 
-                    // If there has already been a backup, just delete the original.
+                    // If there has already been a backup, delete it.
                     if (File.Exists(backupPath))
                     {
-                        File.Delete(path);
+                        File.Delete(backupPath);
                     }
-                    else
-                    {
-                        // Backup the original if there is not already a backup.
-                        File.Move(path, backupPath);
-                    }
+
+                    // Backup the last config.
+                    File.Move(path, backupPath);
                 }
 
                 File.Move(temporaryPath, path);

--- a/TorSharp/Tools/LineByLineConfigurer.cs
+++ b/TorSharp/Tools/LineByLineConfigurer.cs
@@ -57,14 +57,24 @@ namespace Knapcode.TorSharp.Tools
                     }
                 }
 
+                // If the original file exists, remove it before copying over the temporary file.
                 if (File.Exists(path))
                 {
-                    File.Replace(temporaryPath, path, null);
+                    string backupPath = path + ".bak";
+
+                    // If there has already been a backup, just delete the original.
+                    if (File.Exists(backupPath))
+                    {
+                        File.Delete(path);
+                    }
+                    else
+                    {
+                        // Backup the original if there is not already a backup.
+                        File.Move(path, backupPath);
+                    }
                 }
-                else
-                {
-                    File.Move(temporaryPath, path);
-                }
+
+                File.Move(temporaryPath, path);
             }
             finally
             {


### PR DESCRIPTION
I've been experiencing exceptions when replacing the configuration files.
```
System.IO.IOException: Unable to remove the file to be replaced.
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.__Error.WinIOError()
   at System.IO.File.InternalReplace(String sourceFileName, String destinationFileName, String destinationBackupFileName, Boolean ignoreMetadataErrors)
   at System.IO.File.Replace(String sourceFileName, String destinationFileName, String destinationBackupFileName)
   at Knapcode.TorSharp.Tools.LineByLineConfigurer.<ApplySettings>d__3.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter.GetResult()
   at Knapcode.TorSharp.TorSharpProxy.<ConfigureAndStartAsync>d__13.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult()
   at Knapcode.TorSharp.TorSharpProxy.<InitializeAsync>d__9.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter.GetResult()
   at Knapcode.TorSharp.TorSharpProxy.<ConfigureAndStartAsync>d__8.MoveNext()
   --- End of inner exception stack trace ---
```

While I never established the root cause, this [SO answer](http://stackoverflow.com/a/8964246) indicated some other process could be accessing the file and causing issues.

Through trial an error I found deleting the configuration file prior to moving the new version solved the issue. I've also decided to backup the original configuration file as it may aid future diagnosis.