### PR TITLE
Allow the tor data directory to be specified

### DIFF
--- a/TorSharp/Tools/Tor/TorConfigurationDictionary.cs
+++ b/TorSharp/Tools/Tor/TorConfigurationDictionary.cs
@@ -19,6 +19,11 @@ namespace Knapcode.TorSharp.Tools.Tor
                 dictionary["HashedControlPassword"] = settings.HashedTorControlPassword;
             }
 
+            if (!string.IsNullOrWhiteSpace(settings.TorDataDirectory))
+            {
+                dictionary["DataDirectory"] = settings.TorDataDirectory;
+            }
+
             return dictionary;
         }
     }

--- a/TorSharp/TorSharpSettings.cs
+++ b/TorSharp/TorSharpSettings.cs
@@ -24,5 +24,6 @@ namespace Knapcode.TorSharp
         public int PrivoxyPort { get; set; }
         public string TorControlPassword { get; set; }
         public string HashedTorControlPassword { get; set; }
+        public string TorDataDirectory { get; set; }
     }
 }


### PR DESCRIPTION
This is needed if multiple instances of the tor process need to be executed simultaneously. If not specified the multiple instances try to write to the same directory.

I got the answer from [this question](http://serverfault.com/a/328458) of server fault.