### PR TITLE
Added the simple tool runner

### DIFF
--- a/TorSharp/Tools/SimpleToolRunner.cs
+++ b/TorSharp/Tools/SimpleToolRunner.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace Knapcode.TorSharp.Tools
+{
+    public class SimpleToolRunner : IToolRunner, IDisposable
+    {
+        private static readonly Task CompletedTask = Task.FromResult(0);
+        private bool _disposed;
+        private readonly ConcurrentBag<Process> _processes = new ConcurrentBag<Process>();
+
+        ~SimpleToolRunner()
+        {
+            Dispose(false);
+        }
+
+        public Task StartAsync(Tool tool)
+        {
+            // start the desired process
+            var arguments = string.Join(" ", tool.Settings.GetArguments(tool));
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = tool.ExecutablePath,
+                Arguments = arguments,
+                WorkingDirectory = tool.WorkingDirectory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                WindowStyle = ProcessWindowStyle.Hidden,
+            };
+
+            Process process = Process.Start(startInfo);
+
+            if (process == null)
+            {
+                throw new TorSharpException($"Unable to start the process '{tool.ExecutablePath}'.");
+            }
+
+            _processes.Add(process);
+
+            return CompletedTask;
+        }
+
+        public void Stop()
+        {
+            while (!_processes.IsEmpty)
+            {
+                Process process;
+                _processes.TryTake(out process);
+
+                // If the process has not yet exited, ask nicely first.
+                if (!process.HasExited)
+                {
+                    if (process.CloseMainWindow())
+                    {
+                        process.WaitForExit(1000);
+                    }
+                }
+
+                // Still not exited? Then it's no more Mr Nice Guy.
+                if (!process.HasExited)
+                {
+                    process.Kill();
+                    process.WaitForExit(1000);
+                }
+            }
+        }
+
+        void IDisposable.Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+                return;
+
+            if (disposing)
+            {
+                try
+                {
+                    Stop();
+                }
+                catch
+                {
+                    // Not much can be done, but must stop this bubbling.
+                }
+            }
+
+            // release any unmanaged objects
+            // set the object references to null
+
+            _disposed = true;
+        }
+    }
+}

--- a/TorSharp/TorSharp.csproj
+++ b/TorSharp/TorSharp.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Tools\IFileFetcher.cs" />
     <Compile Include="Tools\DownloadableFile.cs" />
     <Compile Include="Tools\Privoxy\PrivoxyFetcher.cs" />
+    <Compile Include="Tools\SimpleToolRunner.cs" />
     <Compile Include="TorSharpToolFetcher.cs" />
     <Compile Include="Tools\Tor\TorFetcher.cs" />
     <Compile Include="TorSharpException.cs" />

--- a/TorSharp/TorSharpProxy.cs
+++ b/TorSharp/TorSharpProxy.cs
@@ -41,14 +41,17 @@ namespace Knapcode.TorSharp
         
         private bool _initialized;
         private readonly TorSharpSettings _settings;
-        private readonly ToolRunner _toolRunner;
+        private readonly IToolRunner _toolRunner;
         private Tool _tor;
         private Tool _privoxy;
 
         public TorSharpProxy(TorSharpSettings settings)
         {
             _settings = settings;
-            _toolRunner = new ToolRunner();
+            _toolRunner =
+                settings.ToolRunnerType == ToolRunnerTypes.Default
+                    ? (IToolRunner)new ToolRunner()
+                    : new SimpleToolRunner();
         }
 
         public async Task ConfigureAndStartAsync()

--- a/TorSharp/TorSharpSettings.cs
+++ b/TorSharp/TorSharpSettings.cs
@@ -1,7 +1,24 @@
 using System.IO;
+using Knapcode.TorSharp.Tools;
 
 namespace Knapcode.TorSharp
 {
+    /// <summary>
+    /// The types of tools runner.
+    /// </summary>
+    public enum ToolRunnerTypes
+    {
+        /// <summary>
+        /// The default tool runner, specifically the <see cref="ToolRunner"/>.
+        /// </summary>
+        Default = 0,
+
+        /// <summary>
+        /// The <see cref="SimpleToolRunner"/>.
+        /// </summary>
+        Simple,
+    }
+
     public class TorSharpSettings
     {
         public static readonly string DefaultToolsDirectory = Path.Combine(Path.GetTempPath(), "Knapcode.TorSharp");
@@ -17,6 +34,7 @@ namespace Knapcode.TorSharp
         }
 
         public bool ReloadTools { get; set; }
+        public ToolRunnerTypes ToolRunnerType { get; set; }
         public string ZippedToolsDirectory { get; set; }
         public string ExtractedToolsDirectory { get; set; }
         public int TorSocksPort { get; set; }


### PR DESCRIPTION
The default tool runner uses several native win32 APIs which work well in a client environment, but can fail in secured/sandboxed server environments. The simple tool runner uses .NET APIs to start the tools which require less permission to run.

To switch between the two tool runners, I've added the enum `ToolRunnerTypes` to the `TorSharpSettings`.