### PR TITLE
Add throwOnError condition to WindowsApi.SetInformationJobObject result.

### DIFF
--- a/TorSharp/Tools/ToolRunner.cs
+++ b/TorSharp/Tools/ToolRunner.cs
@@ -62,7 +62,7 @@ namespace Knapcode.TorSharp.Tools
                         IntPtr extendedPointer = Marshal.AllocHGlobal(length);
                         Marshal.StructureToPtr(extended, extendedPointer, false);
 
-                        if (!WindowsApi.SetInformationJobObject(_jobHandle, WindowsApi.JOBOBJECTINFOCLASS.ExtendedLimitInformation, extendedPointer, (uint) length))
+                        if (!WindowsApi.SetInformationJobObject(_jobHandle, WindowsApi.JOBOBJECTINFOCLASS.ExtendedLimitInformation, extendedPointer, (uint) length) && throwOnError)
                         {
                             throw new TorSharpException($"Unable to set information on the job object. Error: {WindowsUtility.GetLastErrorMessage()}.");
                         }


### PR DESCRIPTION
I was getting a TorSharpException because the result of WindowsApi.SetInformationJobObject is always false, so I added "&& throwOnError" to the condition. I'm not quite sure whether this call should return true in order to work properly, but now it seems to work in my project, and there is always the option of setting throwOnError = true.

If you need more info, just let me know.

Regards.