### PR TITLE
Additional torrc option support.

### DIFF
--- a/TorSharp/Tools/Tor/TorConfigurationDictionary.cs
+++ b/TorSharp/Tools/Tor/TorConfigurationDictionary.cs
@@ -24,6 +24,11 @@ namespace Knapcode.TorSharp.Tools.Tor
                 dictionary["DataDirectory"] = settings.TorDataDirectory;
             }
 
+            if (settings.TorStrictNodes != null)
+            {
+                dictionary["StrictNodes"] = (bool)settings.TorStrictNodes ? "1" : "0";
+            }
+
             return dictionary;
         }
     }

--- a/TorSharp/Tools/Tor/TorConfigurationDictionary.cs
+++ b/TorSharp/Tools/Tor/TorConfigurationDictionary.cs
@@ -1,11 +1,19 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 
 namespace Knapcode.TorSharp.Tools.Tor
 {
     public class TorConfigurationDictionary : IConfigurationDictionary
     {
+        private readonly string _torDirectoryPath;
+
+        public TorConfigurationDictionary(string torDirectoryPath)
+        {
+            _torDirectoryPath = torDirectoryPath;
+        }
+
         public IDictionary<string, string> GetDictionary(TorSharpSettings settings)
         {
             var dictionary = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
@@ -22,6 +30,13 @@ namespace Knapcode.TorSharp.Tools.Tor
             if (!string.IsNullOrWhiteSpace(settings.TorDataDirectory))
             {
                 dictionary["DataDirectory"] = settings.TorDataDirectory;
+            }
+
+            if (settings.TorExitNodes != null)
+            {
+                dictionary["ExitNodes"] = settings.TorExitNodes;
+                dictionary["GeoIPFile"] = Path.Combine(_torDirectoryPath, "Data\\Tor\\geoip");
+                dictionary["GeoIPv6File"] = Path.Combine(_torDirectoryPath, "Data\\Tor\\geoip6");
             }
 
             if (settings.TorStrictNodes != null)

--- a/TorSharp/TorSharpProxy.cs
+++ b/TorSharp/TorSharpProxy.cs
@@ -79,7 +79,7 @@ namespace Knapcode.TorSharp
                 _settings.HashedTorControlPassword = _torPasswordHasher.HashPassword(_settings.TorControlPassword);
             }
 
-            await ConfigureAndStartAsync(_tor, new TorConfigurationDictionary()).ConfigureAwait(false);
+            await ConfigureAndStartAsync(_tor, new TorConfigurationDictionary(_tor.DirectoryPath)).ConfigureAwait(false);
             await ConfigureAndStartAsync(_privoxy, new PrivoxyConfigurationDictionary()).ConfigureAwait(false);
         }
 

--- a/TorSharp/TorSharpSettings.cs
+++ b/TorSharp/TorSharpSettings.cs
@@ -43,6 +43,7 @@ namespace Knapcode.TorSharp
         public string ExtractedToolsDirectory { get; set; }
         public int TorSocksPort { get; set; }
         public int TorControlPort { get; set; }
+        public bool? TorStrictNodes { get; set; }
         public int PrivoxyPort { get; set; }
         public string TorControlPassword { get; set; }
         public string HashedTorControlPassword { get; set; }

--- a/TorSharp/TorSharpSettings.cs
+++ b/TorSharp/TorSharpSettings.cs
@@ -43,6 +43,7 @@ namespace Knapcode.TorSharp
         public string ExtractedToolsDirectory { get; set; }
         public int TorSocksPort { get; set; }
         public int TorControlPort { get; set; }
+        public string TorExitNodes { get; set; }
         public bool? TorStrictNodes { get; set; }
         public int PrivoxyPort { get; set; }
         public string TorControlPassword { get; set; }


### PR DESCRIPTION
I am in no way attached to how the GeoIPFile options are being set. My feeling was that the user of the lib is not necessarily going to know these default locations using the tor copy provided by TorSharp, which made these options not well suited to be specified with TorSharpSettings.