### PR TITLE
External connections to Privoxy

### DIFF
--- a/TorSharp/Tools/Privoxy/PrivoxyConfigurationDictionary.cs
+++ b/TorSharp/Tools/Privoxy/PrivoxyConfigurationDictionary.cs
@@ -9,7 +9,7 @@ namespace Knapcode.TorSharp.Tools.Privoxy
         {
             return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
-                {"listen-address", $"127.0.0.1:{settings.PrivoxySettings.Port}"},
+                {"listen-address", $"{settings.PrivoxySettings.ListenAddress}:{settings.PrivoxySettings.Port}"},
                 {"forward-socks5t", $"/ 127.0.0.1:{settings.TorSettings.SocksPort} ."},
                 {"close-button-minimizes", "1"},
                 {"show-on-task-bar", "0"},

--- a/TorSharp/TorSharpPrivoxySettings.cs
+++ b/TorSharp/TorSharpPrivoxySettings.cs
@@ -10,5 +10,7 @@
         }
 
         public int Port { get; set; }
+
+        public string ListenAddress { get; set; } = "127.0.0.1";
     }
 }


### PR DESCRIPTION
Hello,
I had the task to launch several torus networks and connect to them via an external un IP address.
But there is no such possibility because you have specified listen-address 127.0.0.1 in the Privoxy settings.

PS Sorry for my English.