### PR TITLE
obfs4 bridge support

### DIFF
--- a/src/TorSharp/Tools/Tor/TorConfigurationDictionary.cs
+++ b/src/TorSharp/Tools/Tor/TorConfigurationDictionary.cs
@@ -9,11 +9,27 @@ namespace Knapcode.TorSharp.Tools.Tor
     {
         public IDictionary<string, string> GetDictionary(Tool tool, TorSharpSettings settings)
         {
+            
             var dictionary = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
             {
                 { "SocksPort", settings.TorSettings.SocksPort.ToString(CultureInfo.InvariantCulture) },
                 { "ControlPort", settings.TorSettings.ControlPort.ToString(CultureInfo.InvariantCulture) }
             };
+
+            if (settings.TorSettings.UseBridges.HasValue)
+            {
+                dictionary["UseBridges"] = settings.TorSettings.UseBridges.Value ? "1" : "0";
+            }
+
+            if (!string.IsNullOrWhiteSpace(settings.TorSettings.ClientTransportPlugin))
+            {
+                dictionary["ClientTransportPlugin"] = settings.TorSettings.ClientTransportPlugin;
+            }
+
+            if (!string.IsNullOrWhiteSpace(settings.TorSettings.Bridge))
+            {
+                dictionary["Bridge"] = settings.TorSettings.Bridge;
+            }
 
             if (settings.TorSettings.HashedControlPassword != null)
             {

--- a/src/TorSharp/TorSharpTorSettings.cs
+++ b/src/TorSharp/TorSharpTorSettings.cs
@@ -85,5 +85,25 @@
         /// host machine. 
         /// </summary>
         public string ExecutablePathOverride { get; set; }
+
+        /// <summary>
+        /// See https://www.torproject.org/docs/tor-manual-dev.html.en#UseBridges for more details.
+        /// </summary>
+        public bool? UseBridges { get; set; }
+
+        /// <summary>
+        /// See https://2019.www.torproject.org/docs/tor-manual-dev.html.en#ClientTransportPlugin for more details.
+        /// Path to client transport plugin such as obfs4proxy, snowflake or other.
+        /// ex. [transport] exec [Path]
+        /// </summary>
+        public string ClientTransportPlugin { get; set; }
+
+        /// <summary>
+        /// See https://2019.www.torproject.org/docs/tor-manual-dev.html.en#Bridge for more details.
+        /// Transport plugin bridge.
+        /// ex. bridge [transport] ip:port [fingerprint] key1=val2 key2=val2 keyN=valN...
+        /// </summary>
+        public string Bridge { get; set; }
+
     }
 }


### PR DESCRIPTION
#48 
#54 

- [x] Torrc can handle more than one bridge, please fix LineByLineConfigurer & TorConfigurationDictionary, dictionary can handle only uniq keys.

First of all you need obfs4proxy.exe for windows 
Download tor browser - https://www.torproject.org/download/ .
or "apt-get install obfs4proxy" for *nix.

-Then copy `TorBrowser\Browser\TorBrowser\Tor\PluggableTransports\obfs4proxy.exe` path into ClientTransportPlugin string.
-Take obfs4 bridge from official site - https://bridges.torproject.org/bridges?transport=obfs4 then copy into Bridge string.
-Turn on UseBridges flag.
>"Make internet work again in your country"

ex.
 ```
TorSettings = new TorSharpTorSettings
                {
                    SocksPort = 1338,
                    ControlPort = 1339,
                    ControlPassword = "foobar",
                    UseBridges = true,
                    Bridge = "obfs4 92.75.116.165:42893 3A76222696BA38823C43521FD604189A285D9859 cert=FR1z74IEj2chaLm4ztMtjnU1X4VfAAC6m6fPVSN37IggVKmhJqH0w81b1eEyYoBYDDAyZQ iat-mode=0",
                    ClientTransportPlugin = "meek_lite,obfs2,obfs3,obfs4,scramblesuit exec D:\\obfs4proxy.exe",
                },
```
Fixes #