### PR TITLE
Privoxy MaxClientConnections support

### DIFF
--- a/src/TorSharp/Tools/Privoxy/PrivoxyConfigurationDictionary.cs
+++ b/src/TorSharp/Tools/Privoxy/PrivoxyConfigurationDictionary.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 
 namespace Knapcode.TorSharp.Tools.Privoxy
@@ -24,6 +25,12 @@ namespace Knapcode.TorSharp.Tools.Privoxy
             {
                 output["confdir"] = Path.Combine(tool.DirectoryPath, "etc", "privoxy");
                 output["logdir"] = Path.Combine(tool.DirectoryPath, "var", "log", "privoxy");
+            }
+
+            if (settings.PrivoxySettings.MaxClientConnections.HasValue)
+            {
+                output["max-client-connections"] =
+                    settings.PrivoxySettings.MaxClientConnections.Value.ToString(CultureInfo.InvariantCulture);
             }
 
             return output;

--- a/src/TorSharp/TorSharpPrivoxySettings.cs
+++ b/src/TorSharp/TorSharpPrivoxySettings.cs
@@ -29,5 +29,11 @@
         /// host machine. 
         /// </summary>
         public string ExecutablePathOverride { get; set; }
+
+        /// <summary>
+        /// Maximum number of client connections that will be served.
+        /// See https://www.privoxy.org/user-manual/config.html#MAX-CLIENT-CONNECTIONS for more details.
+        /// </summary>
+        public int? MaxClientConnections { get; set; }
     }
 }


### PR DESCRIPTION
Add support to override the Privoxy max-client-connections property. So we can do more than 100 parallel request through your wonderful library. 