### PR TITLE
Add a link to a full tor configuration sample in torrc

### DIFF
--- a/src/TorSharp/Tools/LineByLineConfigurer.cs
+++ b/src/TorSharp/Tools/LineByLineConfigurer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -36,7 +37,8 @@ namespace Knapcode.TorSharp.Tools
                 }
                 else
                 {
-                    reader = new StringReader(string.Empty);
+                    // Append a link to a configuration sample at the top.
+                    reader = new StringReader("# Full sample at https://github.com/torproject/tor/blob/master/src/config/torrc.sample.in");
                 }
 
                 using (reader)


### PR DESCRIPTION
When applying the configuration to the torrc file, it's useful to point
to a more comprehensive example of all the available options, even if
they aren't directly surfaced by TorSharp.

Fixes #71