### PR TITLE
Use tor-win64 when running on X64 Windows

### DIFF
--- a/src/TorSharp/ToolUtility.cs
+++ b/src/TorSharp/ToolUtility.cs
@@ -109,7 +109,7 @@ namespace Knapcode.TorSharp
                 return new ToolSettings
                 {
                     Name = TorName,
-                    Prefix = "tor-win32-",
+                    Prefix = settings.Architecture == TorSharpArchitecture.X64 ? "tor-win64-" : "tor-win32-",
                     ExecutablePathOverride = settings.TorSettings.ExecutablePathOverride,
                     ExecutablePath = Path.Combine(TorName, "tor.exe"),
                     WorkingDirectory = TorName,

--- a/src/TorSharp/Tools/Tor/TorFetcher.cs
+++ b/src/TorSharp/Tools/Tor/TorFetcher.cs
@@ -44,7 +44,14 @@ namespace Knapcode.TorSharp.Tools.Tor
             var format = default(ZippedToolFormat);
             if (_settings.OSPlatform == TorSharpOSPlatform.Windows)
             {
-                pattern = @"tor-win32-(?<Version>[\d\.]+)\.zip$";
+                if (_settings.Architecture == TorSharpArchitecture.X64)
+                {
+                    pattern = @"tor-win64-(?<Version>[\d\.]+)\.zip$";
+                }
+                else
+                {
+                    pattern = @"tor-win32-(?<Version>[\d\.]+)\.zip$";
+                }
                 format = ZippedToolFormat.Zip;
             }
             else if (_settings.OSPlatform == TorSharpOSPlatform.Linux)


### PR DESCRIPTION
The releases contain tor-win64, which should be used when running on Windows X64. instead of hardcoding win-32.

Fixes #74