### PR TITLE
ARM architecture support.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,8 @@
     <BranchVersionLabel Condition="'$(BranchVersionLabel)' == '' and '$(GITHUB_HEAD_REF)' != ''">$(GITHUB_HEAD_REF)</BranchVersionLabel>
     <BranchVersionLabel Condition="'$(BranchVersionLabel)' == '' and '$(GITHUB_REF)' != ''">$(GITHUB_REF)</BranchVersionLabel>
     <BranchVersionLabel Condition="'$(BranchVersionLabel)' != ''">$([System.Text.RegularExpressions.Regex]::Replace("$(BranchVersionLabel)", "^(.+/)?([^/]+)$", "ci.$2"))</BranchVersionLabel>
+    <BranchVersionLabel Condition="'$(BranchVersionLabel)' != ''">$([System.Text.RegularExpressions.Regex]::Replace($(BranchVersionLabel), '[^0-9A-Za-z\-\.]+', '-'))</BranchVersionLabel>
+    <BranchVersionLabel Condition="'$(BranchVersionLabel)' != ''">$([System.Text.RegularExpressions.Regex]::Replace($(BranchVersionLabel), '\.0+(\d+(\.|$))', '.$1'))</BranchVersionLabel>
     <BranchVersionLabel Condition="'$(BranchVersionLabel)' == ''">local</BranchVersionLabel>
 
     <BuildVersionLabel Condition="'$(BuildVersionLabel)' == '' and '$(GITHUB_RUN_NUMBER)' != ''">.$(GITHUB_RUN_NUMBER)</BuildVersionLabel>

--- a/src/TorSharp/ToolUtility.cs
+++ b/src/TorSharp/ToolUtility.cs
@@ -290,7 +290,7 @@ namespace Knapcode.TorSharp
                 return false;
 
             // In linux most binaries exists in any bin directory, e.g /bin/ /sbin/ /usr/bin/
-            var toolPath = WhereisUtility.Whereis(toolSettings.TryFindExecutableName);
+            var toolPath = WhereIsUtility.WhereIs(toolSettings.TryFindExecutableName);
             var toolVariants = toolPath.Split(new char[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
             var binToolVariant = Array.Find(toolVariants,
                 a => Regex.IsMatch(a, $@"\/bin\/.*{toolSettings.TryFindExecutableName}"));

--- a/src/TorSharp/ToolUtility.cs
+++ b/src/TorSharp/ToolUtility.cs
@@ -141,7 +141,7 @@ namespace Knapcode.TorSharp
                 {
                     prefix = "tor-linux64-";
                 }
-                else if (settings.Architecture.HasFlag(TorSharpArchitecture.Arm))
+                else if (settings.Architecture.Contains("Arm"))
                 {
                     if (settings.Architecture == TorSharpArchitecture.Arm32)
                     {
@@ -286,14 +286,10 @@ namespace Knapcode.TorSharp
         public static bool TryFindToolInSystem(TorSharpSettings settings, ToolSettings toolSettings, out Tool tool)
         {
             tool = null;
-            if (settings.OSPlatform != TorSharpOSPlatform.Linux) // For windows search exe name in PATH variable?
-                return false;
 
-            // In linux most binaries exists in any bin directory, e.g /bin/ /sbin/ /usr/bin/
-            var toolPath = WhereIsUtility.WhereIs(toolSettings.TryFindExecutableName);
+            var toolPath = WhichUtility.Which(settings, toolSettings.TryFindExecutableName);
             var toolVariants = toolPath.Split(new char[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-            var binToolVariant = Array.Find(toolVariants,
-                a => Regex.IsMatch(a, $@"\/bin\/.*{toolSettings.TryFindExecutableName}"));
+            var binToolVariant = toolVariants.FirstOrDefault();
             if (!string.IsNullOrEmpty(binToolVariant))
             {
                 var directoryPath = Path.Combine(settings.ExtractedToolsDirectory, "local");

--- a/src/TorSharp/ToolUtility.cs
+++ b/src/TorSharp/ToolUtility.cs
@@ -286,7 +286,9 @@ namespace Knapcode.TorSharp
         {
             tool = null;
 
-            var toolPath = WhichUtility.Which(settings, toolSettings.TryFindExecutableName);
+            var toolPath = settings.OSPlatform == TorSharpOSPlatform.Linux ?
+                WhichUtility.Which(toolSettings.TryFindExecutableName) : // Linux
+                SearchInPathHelper.SearchInPathVariable(toolSettings.TryFindExecutableName); // Windows
             var toolVariants = toolPath.Split(new char[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
             var binToolVariant = toolVariants.FirstOrDefault();
             if (!string.IsNullOrEmpty(binToolVariant))

--- a/src/TorSharp/ToolUtility.cs
+++ b/src/TorSharp/ToolUtility.cs
@@ -131,6 +131,10 @@ namespace Knapcode.TorSharp
                 {
                     prefix = "tor-linux64-";
                 }
+                else if (settings.Architecture == TorSharpArchitecture.Arm64)
+                {
+                    prefix = "tor-linux-aarch64-";
+                }
                 else
                 {
                     settings.RejectRuntime("determine Linux Tor prefix");

--- a/src/TorSharp/ToolUtility.cs
+++ b/src/TorSharp/ToolUtility.cs
@@ -41,7 +41,7 @@ namespace Knapcode.TorSharp
 
                         return e;
                     },
-                    TryFindInSystem = settings.TorSettings.AutomateFindInSystem,
+                    TryFindInSystem = settings.TorSettings.AutomaticallyFindInSystem,
                     TryFindExecutableName = "privoxy.exe"
                 };
             }
@@ -96,7 +96,7 @@ namespace Knapcode.TorSharp
                             return null;
                         }
                     },
-                    TryFindInSystem = settings.TorSettings.AutomateFindInSystem,
+                    TryFindInSystem = settings.TorSettings.AutomaticallyFindInSystem,
                     TryFindExecutableName = "privoxy"
                 };
             }
@@ -124,7 +124,7 @@ namespace Knapcode.TorSharp
                     GetEnvironmentVariables = t => new Dictionary<string, string>(),
                     ZippedToolFormat = ZippedToolFormat.TarGz,
                     GetEntryPath = e => e,
-                    TryFindInSystem = settings.TorSettings.AutomateFindInSystem,
+                    TryFindInSystem = settings.TorSettings.AutomaticallyFindInSystem,
                     TryFindExecutableName = "tor.exe"
                 };
             }
@@ -216,7 +216,7 @@ namespace Knapcode.TorSharp
                     },
                     ZippedToolFormat = archiveFormat,
                     GetEntryPath = getEntryPath,
-                    TryFindInSystem = settings.TorSettings.AutomateFindInSystem,
+                    TryFindInSystem = settings.TorSettings.AutomaticallyFindInSystem,
                     TryFindExecutableName = "tor"
                 };
             }
@@ -310,7 +310,7 @@ namespace Knapcode.TorSharp
                     ExecutablePath = binToolVariant,
                     WorkingDirectory = workingDirectory,
                     ConfigurationPath = configurationPath,
-                    AutomateDetected = true
+                    AutomaticallyDetected = true
                 };
             }
             return true;

--- a/src/TorSharp/ToolUtility.cs
+++ b/src/TorSharp/ToolUtility.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 
 using Knapcode.TorSharp.Tools;
 
@@ -141,7 +140,7 @@ namespace Knapcode.TorSharp
                 {
                     prefix = "tor-linux64-";
                 }
-                else if (settings.Architecture.Contains("Arm"))
+                else if (settings.Architecture.IsArm())
                 {
                     if (settings.Architecture == TorSharpArchitecture.Arm32)
                     {

--- a/src/TorSharp/Tools/ArchiveUtility.cs
+++ b/src/TorSharp/Tools/ArchiveUtility.cs
@@ -61,19 +61,14 @@ namespace Knapcode.TorSharp.Tools
 
         public static string GetFileExtension(ZippedToolFormat format)
         {
-            switch (format)
+            return format switch
             {
-                case ZippedToolFormat.Zip:
-                    return ".zip";
-                case ZippedToolFormat.Deb:
-                    return ".deb";
-                case ZippedToolFormat.TarXz:
-                    return ".tar.xz";
-                case ZippedToolFormat.TarGz:
-                    return ".tar.gz";
-                default:
-                    throw new NotImplementedException($"The zipped tool format {format} does not have a known extension.");
-            }
+                ZippedToolFormat.Zip => ".zip",
+                ZippedToolFormat.Deb => ".deb",
+                ZippedToolFormat.TarXz => ".tar.xz",
+                ZippedToolFormat.TarGz => ".tar.gz",
+                _ => throw new NotImplementedException($"The zipped tool format {format} does not have a known extension."),
+            };
         }
 
         public static async Task TestZipAsync(string zipPath)
@@ -245,7 +240,7 @@ namespace Knapcode.TorSharp.Tools
             }
         }
 
-        private class ArFileHeader
+        private sealed class ArFileHeader
         {
             public ArFileHeader(string fileIdentifier, uint fileSize)
             {

--- a/src/TorSharp/Tools/ArchiveUtility.cs
+++ b/src/TorSharp/Tools/ArchiveUtility.cs
@@ -9,7 +9,7 @@ using SharpCompress.Readers.Tar;
 
 namespace Knapcode.TorSharp.Tools
 {
-    internal class ArchiveUtility
+    internal static class ArchiveUtility
     {
         public static async Task TestAsync(ZippedToolFormat format, string path)
         {

--- a/src/TorSharp/Tools/DirectoryUtility.cs
+++ b/src/TorSharp/Tools/DirectoryUtility.cs
@@ -1,0 +1,19 @@
+﻿using System.IO;
+
+namespace Knapcode.TorSharp.Tools
+{
+    internal static class DirectoryUtility
+    {
+        public static void CreateDirectoryIfNotExists(params string[] path)
+        {
+            foreach (var p in path)
+                CreateDirectoryIfNotExists(p);
+        }
+
+        public static void CreateDirectoryIfNotExists(string path)
+        {
+            if (!Directory.Exists(path))
+                Directory.CreateDirectory(path);
+        }
+    }
+}

--- a/src/TorSharp/Tools/EnumHelper.cs
+++ b/src/TorSharp/Tools/EnumHelper.cs
@@ -4,9 +4,9 @@ namespace Knapcode.TorSharp.Tools
 {
     internal static class EnumHelper
     {
-        public static bool Contains<T>(this T value, string enumValue) where T : Enum
+        public static bool IsArm(this TorSharpArchitecture arch)
         {
-            return value.ToString().Contains(enumValue);
+            return arch == TorSharpArchitecture.Arm32 || arch == TorSharpArchitecture.Arm64;
         }
     }
 }

--- a/src/TorSharp/Tools/EnumHelper.cs
+++ b/src/TorSharp/Tools/EnumHelper.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Knapcode.TorSharp.Tools
+{
+    internal static class EnumHelper
+    {
+        public static bool Contains<T>(this T value, string enumValue) where T : Enum
+        {
+            return value.ToString().Contains(enumValue);
+        }
+    }
+}

--- a/src/TorSharp/Tools/LineByLineConfigurer.cs
+++ b/src/TorSharp/Tools/LineByLineConfigurer.cs
@@ -26,7 +26,7 @@ namespace Knapcode.TorSharp.Tools
             try
             {
                 // write first to a temporary file
-                temporaryPath = Path.GetTempFileName();
+                temporaryPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
                 TextReader reader;
 
                 // read the existing configuration, if there is some

--- a/src/TorSharp/Tools/LineByLineConfigurer.cs
+++ b/src/TorSharp/Tools/LineByLineConfigurer.cs
@@ -57,15 +57,12 @@ namespace Knapcode.TorSharp.Tools
                     // write the remaining lines
                     foreach (var pair in dictionary.OrderBy(p => p.Key))
                     {
-                        if (pair.Value != null && pair.Value.Any())
+                        if (pair.Value?.Any() == true)
                         {
-                            foreach (var value in pair.Value)
+                            foreach (var value in pair.Value.Where(a => a != null))
                             {
-                                if (value != null)
-                                {
-                                    string newLine = _format.CreateLine(new KeyValuePair<string, string>(pair.Key, value));
-                                    await writer.WriteLineAsync(newLine).ConfigureAwait(false);
-                                }
+                                string newLine = _format.CreateLine(new KeyValuePair<string, string>(pair.Key, value));
+                                await writer.WriteLineAsync(newLine).ConfigureAwait(false);
                             }
                         }
                     }
@@ -109,7 +106,6 @@ namespace Knapcode.TorSharp.Tools
                     }
                 }
             }
-
         }
     }
 }

--- a/src/TorSharp/Tools/Privoxy/PrivoxyFetcher.cs
+++ b/src/TorSharp/Tools/Privoxy/PrivoxyFetcher.cs
@@ -91,7 +91,7 @@ namespace Knapcode.TorSharp.Tools.Privoxy
                     await Task.WhenAll(faults).ConfigureAwait(false);
                 }
 
-                throw new TorSharpException($"No version of Privoxy could be found.");
+                throw new TorSharpException("No version of Privoxy could be found.");
             }
 
             return results;
@@ -160,8 +160,7 @@ namespace Knapcode.TorSharp.Tools.Privoxy
 
             var downloadableFile = syndicationFeed
                 .Items
-                .Where(i => i.Links.Any())
-                .Where(i => TitleStartWithDirectory(directory, i))
+                .Where(i => i.Links.Any() && TitleStartWithDirectory(directory, i))
                 .Select(i => FetcherHelpers.GetDownloadableFile(fileNamePatternAndFormat, i))
                 .Where(i => i != null)
                 .OrderByDescending(x => x.Version)

--- a/src/TorSharp/Tools/Privoxy/PrivoxyFetcher.cs
+++ b/src/TorSharp/Tools/Privoxy/PrivoxyFetcher.cs
@@ -121,8 +121,7 @@ namespace Knapcode.TorSharp.Tools.Privoxy
             var downloadableFile = await FetcherHelpers.GetLatestDownloadableFileAsync(
                 _httpClient,
                 osBaseUrl,
-                fileNamePatternAndFormat.Pattern,
-                fileNamePatternAndFormat.Format,
+                fileNamePatternAndFormat,
                 token).ConfigureAwait(false);
 
             if (downloadableFile == null)
@@ -163,7 +162,7 @@ namespace Knapcode.TorSharp.Tools.Privoxy
                 .Items
                 .Where(i => i.Links.Any())
                 .Where(i => TitleStartWithDirectory(directory, i))
-                .Select(i => GetDownloadableFile(fileNamePatternAndFormat.Pattern, fileNamePatternAndFormat.Format, i))
+                .Select(i => FetcherHelpers.GetDownloadableFile(fileNamePatternAndFormat, i))
                 .Where(i => i != null)
                 .OrderByDescending(x => x.Version)
                 .FirstOrDefault();
@@ -184,30 +183,6 @@ namespace Knapcode.TorSharp.Tools.Privoxy
                 item.Title.Text,
                 $"^/?{directory}/",
                 RegexOptions.IgnoreCase);
-        }
-
-        private DownloadableFile GetDownloadableFile(
-            string fileNamePattern,
-            ZippedToolFormat format,
-            SyndicationItem item)
-        {
-            var match = Regex.Match(
-                item.Title.Text,
-                fileNamePattern,
-                RegexOptions.IgnoreCase);
-
-            if (!match.Success)
-            {
-                return null;
-            }
-
-            if (!Version.TryParse(match.Groups["Version"].Value, out var parsedVersion))
-            {
-                return null;
-            }
-
-            var downloadUrl = item.Links.First().Uri;
-            return new DownloadableFile(parsedVersion, downloadUrl, format);
         }
 
         private string GetFileListingDirectory(Uri baseUrl)

--- a/src/TorSharp/Tools/SearchInPathHelper.cs
+++ b/src/TorSharp/Tools/SearchInPathHelper.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+
+namespace Knapcode.TorSharp.Tools
+{
+    public static class SearchInPathHelper
+    {
+        public static string SearchInPathVariable(string pattern)
+        {
+            var variables = Environment.GetEnvironmentVariables();
+            if (!variables.Contains("Path"))
+                return null;
+
+            var what = variables["Path"].ToString()
+                .Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
+                .SelectMany(a => Directory.GetFiles(a, pattern, SearchOption.TopDirectoryOnly));
+
+            return what.FirstOrDefault();
+        }
+    }
+}

--- a/src/TorSharp/Tools/SimpleToolRunner.cs
+++ b/src/TorSharp/Tools/SimpleToolRunner.cs
@@ -34,25 +34,17 @@ namespace Knapcode.TorSharp.Tools
                 startInfo.EnvironmentVariables[pair.Key] = pair.Value;
             }
 
-            Process process = Process.Start(startInfo);
+            Process process = Process.Start(startInfo) ?? 
+                throw new TorSharpException($"Unable to start the process '{tool.ExecutablePath}'.");
 
-            process.OutputDataReceived += (object sender, DataReceivedEventArgs e) =>
-            {
+            process.OutputDataReceived += (object sender, DataReceivedEventArgs e) => 
                 Stdout?.Invoke(this, new DataEventArgs(tool.ExecutablePath, e.Data));
-            };
 
-            process.ErrorDataReceived += (object sender, DataReceivedEventArgs e) =>
-            {
+            process.ErrorDataReceived += (object sender, DataReceivedEventArgs e) => 
                 Stderr?.Invoke(this, new DataEventArgs(tool.ExecutablePath, e.Data));
-            };
 
             process.BeginOutputReadLine();
             process.BeginErrorReadLine();
-
-            if (process == null)
-            {
-                throw new TorSharpException($"Unable to start the process '{tool.ExecutablePath}'.");
-            }
 
             _processes.Add(process);
 

--- a/src/TorSharp/Tools/Tool.cs
+++ b/src/TorSharp/Tools/Tool.cs
@@ -41,5 +41,10 @@ namespace Knapcode.TorSharp.Tools
         /// The full path to the tool's configuration file.
         /// </summary>
         public string ConfigurationPath { get; set; }
+
+        /// <summary>
+        /// Automate detected in system.
+        /// </summary>
+        public bool AutomateDetected { get; set; }
     }
 }

--- a/src/TorSharp/Tools/Tool.cs
+++ b/src/TorSharp/Tools/Tool.cs
@@ -45,6 +45,6 @@ namespace Knapcode.TorSharp.Tools
         /// <summary>
         /// Automate detected in system.
         /// </summary>
-        public bool AutomateDetected { get; set; }
+        public bool AutomaticallyDetected { get; set; }
     }
 }

--- a/src/TorSharp/Tools/ToolSettings.cs
+++ b/src/TorSharp/Tools/ToolSettings.cs
@@ -60,5 +60,15 @@ namespace Knapcode.TorSharp.Tools
         /// executable name present in the PATH variable (e.g. installed to the local machine).
         /// </summary>
         public string ExecutablePathOverride { get; set; }
+
+        /// <summary>
+        /// Try to find tool without download.
+        /// </summary>
+        public bool TryFindInSystem { get; set; }
+
+        /// <summary>
+        /// In linux most binaries exists in any bin directory, e.g /bin/ /sbin/ /usr/bin/
+        /// </summary>
+        public string TryFindExecutableName { get; set; }
     }
 }

--- a/src/TorSharp/Tools/ToolSettings.cs
+++ b/src/TorSharp/Tools/ToolSettings.cs
@@ -62,7 +62,7 @@ namespace Knapcode.TorSharp.Tools
         public string ExecutablePathOverride { get; set; }
 
         /// <summary>
-        /// Try to find tool without download.
+        /// Try to find the tool without downloading it.
         /// </summary>
         public bool TryFindInSystem { get; set; }
 

--- a/src/TorSharp/Tools/Tor/TorConfigurationDictionary.cs
+++ b/src/TorSharp/Tools/Tor/TorConfigurationDictionary.cs
@@ -88,14 +88,7 @@ namespace Knapcode.TorSharp.Tools.Tor
                 dictionary["Bridge"] = settings.TorSettings.Bridge;
             }
 
-            if (settings.TorSettings.HashedControlPassword != null)
-            {
-                dictionary["HashedControlPassword"] = settings.TorSettings.HashedControlPassword;
-            }
-            else
-            {
-                dictionary["HashedControlPassword"] = null;
-            }
+            dictionary["HashedControlPassword"] = settings.TorSettings.HashedControlPassword;
 
             string dataDictionary;
             if (!string.IsNullOrWhiteSpace(settings.TorSettings.DataDirectory))

--- a/src/TorSharp/Tools/Tor/TorControlClient.cs
+++ b/src/TorSharp/Tools/Tor/TorControlClient.cs
@@ -51,7 +51,7 @@ namespace Knapcode.TorSharp.Tools.Tor
             {
                 commandBuilder.AppendFormat(" {0}", keyword);
                 keywordCount++;
-            };
+            }
 
             if (keywordCount == 0)
             {

--- a/src/TorSharp/Tools/Tor/TorFetcher.cs
+++ b/src/TorSharp/Tools/Tor/TorFetcher.cs
@@ -1,13 +1,19 @@
 ﻿using System;
+using System.IO;
+using System.Linq;
 using System.Net.Http;
+using System.ServiceModel.Syndication;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml;
 
 namespace Knapcode.TorSharp.Tools.Tor
 {
     internal class TorFetcher : IFileFetcher
     {
         private static readonly Uri BaseUrl = new Uri("https://dist.torproject.org/torbrowser/");
+        private static readonly Uri BaseArmUrl = new Uri("https://sourceforge.net/projects/tor-browser-ports/rss");
         private readonly TorSharpSettings _settings;
         private readonly HttpClient _httpClient;
 
@@ -20,13 +26,26 @@ namespace Knapcode.TorSharp.Tools.Tor
         public async Task<DownloadableFile> GetLatestAsync()
         {
             var fileNamePatternAndFormat = GetFileNamePatternAndFormat();
+            DownloadableFile downloadableFile;
 
-            var downloadableFile = await FetcherHelpers.GetLatestDownloadableFileAsync(
-                _httpClient,
-                BaseUrl,
-                fileNamePatternAndFormat.Pattern,
-                fileNamePatternAndFormat.Format,
-                CancellationToken.None).ConfigureAwait(false);
+            if (_settings.Architecture.HasFlag(TorSharpArchitecture.Arm))
+            {
+                if (!_settings.AllowUnofficialSources)
+                    throw new TorSharpException($"AllowUnofficialDistribution == false, there is no official tor distribution for {_settings.Architecture} platform.");
+
+                downloadableFile = await GetLatestDownloadableArmFileAsync(_httpClient,
+                    BaseArmUrl,
+                    fileNamePatternAndFormat,
+                    CancellationToken.None).ConfigureAwait(false);
+            }
+            else
+            {
+                downloadableFile = await FetcherHelpers.GetLatestDownloadableFileAsync(
+                    _httpClient,
+                    BaseUrl,
+                    fileNamePatternAndFormat,
+                    CancellationToken.None).ConfigureAwait(false);
+            }
 
             if (downloadableFile == null)
             {
@@ -56,6 +75,7 @@ namespace Knapcode.TorSharp.Tools.Tor
             }
             else if (_settings.OSPlatform == TorSharpOSPlatform.Linux)
             {
+                format = ZippedToolFormat.TarGz;
                 if (_settings.Architecture == TorSharpArchitecture.X86)
                 {
                     pattern = @"tor-expert-bundle-(?<Version>[\d\.]+)-linux-i686\.tar\.gz$";
@@ -64,7 +84,13 @@ namespace Knapcode.TorSharp.Tools.Tor
                 {
                     pattern = @"tor-expert-bundle-(?<Version>[\d\.]+)-linux-x86_64\.tar\.gz$";
                 }
-                format = ZippedToolFormat.TarGz;
+                else if (_settings.Architecture.HasFlag(TorSharpArchitecture.Arm))
+                {
+                    // Version twice to skip ALSA versions - https://github.com/alsa-project
+                    var arch = _settings.Architecture == TorSharpArchitecture.Arm64 ? "arm64" : "armhf";
+                    pattern = @$"(?<Version>[\d\.]+)\/tor-browser-linux-{arch}-(?<Version1>[\d\.]+)_ALL\.tar\.xz$";
+                    format = ZippedToolFormat.TarXz;
+                }
             }
 
             if (pattern == null)
@@ -73,6 +99,60 @@ namespace Knapcode.TorSharp.Tools.Tor
             }
 
             return new FileNamePatternAndFormat(pattern, format);
+        }
+
+        public async Task<DownloadableFile> GetLatestDownloadableArmFileAsync(HttpClient httpClient,
+            Uri baseUrl,
+            FileNamePatternAndFormat patternAndFormat,
+            CancellationToken token)
+        {
+            SyndicationFeed syndicationFeed;
+            using (var response = await httpClient.GetAsync(baseUrl, HttpCompletionOption.ResponseContentRead, token).ConfigureAwait(false))
+            {
+                response.EnsureSuccessStatusCode();
+
+                using (var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
+                {
+                    var streamReader = new StreamReader(stream);
+                    var xmlReader = XmlReader.Create(streamReader);
+                    syndicationFeed = SyndicationFeed.Load(xmlReader);
+                    if (syndicationFeed == null)
+                    {
+                        return null;
+                    }
+                }
+
+                return syndicationFeed.Items
+                    .Where(i => i.Links.Any())
+                    .Select(i => GetDownloadableFile(patternAndFormat.Pattern, patternAndFormat.Format, i))
+                    .Where(i => i != null)
+                    .OrderByDescending(x => x.Version)
+                    .FirstOrDefault();
+            }
+        }
+
+        private DownloadableFile GetDownloadableFile(
+            string fileNamePattern,
+            ZippedToolFormat format,
+            SyndicationItem item)
+        {
+            var match = Regex.Match(
+                item.Title.Text,
+                fileNamePattern,
+                RegexOptions.IgnoreCase);
+
+            if (!match.Success)
+            {
+                return null;
+            }
+
+            if (!Version.TryParse(match.Groups["Version"].Value, out var parsedVersion))
+            {
+                return null;
+            }
+
+            var downloadUrl = item.Links.First().Uri;
+            return new DownloadableFile(parsedVersion, downloadUrl, format);
         }
     }
 }

--- a/src/TorSharp/Tools/Tor/TorFetcher.cs
+++ b/src/TorSharp/Tools/Tor/TorFetcher.cs
@@ -31,7 +31,7 @@ namespace Knapcode.TorSharp.Tools.Tor
             if (_settings.Architecture.HasFlag(TorSharpArchitecture.Arm))
             {
                 if (!_settings.AllowUnofficialSources)
-                    throw new TorSharpException($"AllowUnofficialDistribution == false, there is no official tor distribution for {_settings.Architecture} platform.");
+                    throw new TorSharpException($"{nameof(AllowUnofficialDistribution)} == false, there is no official tor distribution for {_settings.Architecture} platform.");
 
                 downloadableFile = await GetLatestDownloadableArmFileAsync(_httpClient,
                     BaseArmUrl,

--- a/src/TorSharp/Tools/Tor/TorFetcher.cs
+++ b/src/TorSharp/Tools/Tor/TorFetcher.cs
@@ -31,7 +31,7 @@ namespace Knapcode.TorSharp.Tools.Tor
             if (_settings.Architecture.HasFlag(TorSharpArchitecture.Arm))
             {
                 if (!_settings.AllowUnofficialSources)
-                    throw new TorSharpException($"{nameof(AllowUnofficialDistribution)} == false, there is no official tor distribution for {_settings.Architecture} platform.");
+                    throw new TorSharpException($"{nameof(_settings.AllowUnofficialSources)} == false, there is no official tor distribution for {_settings.Architecture} platform.");
 
                 downloadableFile = await GetLatestDownloadableArmFileAsync(_httpClient,
                     BaseArmUrl,

--- a/src/TorSharp/Tools/Tor/TorFetcher.cs
+++ b/src/TorSharp/Tools/Tor/TorFetcher.cs
@@ -28,7 +28,7 @@ namespace Knapcode.TorSharp.Tools.Tor
             var fileNamePatternAndFormat = GetFileNamePatternAndFormat();
             DownloadableFile downloadableFile;
 
-            if (_settings.Architecture.Contains("Arm"))
+            if (_settings.Architecture.IsArm())
             {
                 if (!_settings.AllowUnofficialSources)
                     throw new TorSharpException($"{nameof(_settings.AllowUnofficialSources)} == false, there is no official tor distribution for {_settings.Architecture} platform.");
@@ -84,7 +84,7 @@ namespace Knapcode.TorSharp.Tools.Tor
                 {
                     pattern = @"tor-expert-bundle-(?<Version>[\d\.]+)-linux-x86_64\.tar\.gz$";
                 }
-                else if (_settings.Architecture.Contains("Arm"))
+                else if (_settings.Architecture.IsArm())
                 {
                     // Version twice to skip ALSA versions - https://github.com/alsa-project
                     var arch = _settings.Architecture == TorSharpArchitecture.Arm64 ? "arm64" : "armhf";

--- a/src/TorSharp/Tools/Tor/TorFetcher.cs
+++ b/src/TorSharp/Tools/Tor/TorFetcher.cs
@@ -151,7 +151,7 @@ namespace Knapcode.TorSharp.Tools.Tor
                 return null;
             }
 
-            var downloadUrl = item.Links.First().Uri;
+            var downloadUrl = item.Links[0].Uri;
             return new DownloadableFile(parsedVersion, downloadUrl, format);
         }
     }

--- a/src/TorSharp/Tools/WhereisUtility.cs
+++ b/src/TorSharp/Tools/WhereisUtility.cs
@@ -1,0 +1,44 @@
+﻿using System.Diagnostics;
+using System.Text;
+
+namespace Knapcode.TorSharp.Tools
+{
+    internal class WhereisUtility
+    {
+        public static string Whereis(string searchPattern)
+        {
+            using (var process = new Process())
+            {
+                process.StartInfo.FileName = "whereis";
+                process.StartInfo.Arguments = searchPattern;
+                process.StartInfo.RedirectStandardOutput = true;
+                process.StartInfo.RedirectStandardError = true;
+                process.StartInfo.CreateNoWindow = true;
+                process.StartInfo.UseShellExecute = false;
+
+                var output = new StringBuilder();
+                var outputLock = new object();
+                process.OutputDataReceived += GetOutputHandler(output, outputLock);
+                process.ErrorDataReceived += GetOutputHandler(output, outputLock);
+
+                process.Start();
+                process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
+                process.WaitForExit();
+
+                return output.ToString();
+            }
+        }
+
+        private static DataReceivedEventHandler GetOutputHandler(StringBuilder output, object outputLock)
+        {
+            return (object sender, DataReceivedEventArgs e) =>
+            {
+                lock (outputLock)
+                {
+                    output.AppendLine(e.Data);
+                }
+            };
+        }
+    }
+}

--- a/src/TorSharp/Tools/WhereisUtility.cs
+++ b/src/TorSharp/Tools/WhereisUtility.cs
@@ -3,9 +3,9 @@ using System.Text;
 
 namespace Knapcode.TorSharp.Tools
 {
-    internal class WhereisUtility
+    internal static class WhereIsUtility
     {
-        public static string Whereis(string searchPattern)
+        public static string WhereIs(string searchPattern)
         {
             using (var process = new Process())
             {

--- a/src/TorSharp/Tools/WhichUtility.cs
+++ b/src/TorSharp/Tools/WhichUtility.cs
@@ -1,52 +1,32 @@
-﻿using System;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
+﻿using System.Diagnostics;
 using System.Text;
 
 namespace Knapcode.TorSharp.Tools
 {
     internal static class WhichUtility
     {
-        public static string Which(TorSharpSettings settings, string searchPattern)
+        public static string Which(string searchPattern)
         {
-            if (settings.OSPlatform == TorSharpOSPlatform.Windows)
-                return SearchInPathVariable(searchPattern);
+            using var process = new Process();
 
-            using (var process = new Process())
-            {
-                process.StartInfo.FileName = "which";
-                process.StartInfo.Arguments = searchPattern;
-                process.StartInfo.RedirectStandardOutput = true;
-                process.StartInfo.RedirectStandardError = true;
-                process.StartInfo.CreateNoWindow = true;
-                process.StartInfo.UseShellExecute = false;
+            process.StartInfo.FileName = "which";
+            process.StartInfo.Arguments = searchPattern;
+            process.StartInfo.RedirectStandardOutput = true;
+            process.StartInfo.RedirectStandardError = true;
+            process.StartInfo.CreateNoWindow = true;
+            process.StartInfo.UseShellExecute = false;
 
-                var output = new StringBuilder();
-                var outputLock = new object();
-                process.OutputDataReceived += GetOutputHandler(output, outputLock);
-                process.ErrorDataReceived += GetOutputHandler(output, outputLock);
+            var output = new StringBuilder();
+            var outputLock = new object();
+            process.OutputDataReceived += GetOutputHandler(output, outputLock);
+            process.ErrorDataReceived += GetOutputHandler(output, outputLock);
 
-                process.Start();
-                process.BeginOutputReadLine();
-                process.BeginErrorReadLine();
-                process.WaitForExit();
+            process.Start();
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+            process.WaitForExit();
 
-                return output.ToString();
-            }
-        }
-
-        private static string SearchInPathVariable(string pattern)
-        {
-            var variables = Environment.GetEnvironmentVariables();
-            if (!variables.Contains("Path"))
-                return null;
-
-            var what = variables["Path"].ToString()
-                .Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
-                .SelectMany(a => Directory.GetFiles(a, pattern, SearchOption.TopDirectoryOnly));
-
-            return what.FirstOrDefault();
+            return output.ToString();
         }
 
         private static DataReceivedEventHandler GetOutputHandler(StringBuilder output, object outputLock)

--- a/src/TorSharp/TorSharp.csproj
+++ b/src/TorSharp/TorSharp.csproj
@@ -1,12 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(CoreOnly)' != 'true'">net472;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(CoreOnly)' != 'true'">net462;net472;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(CoreOnly)' == 'true'">netstandard2.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
     <AssemblyName>Knapcode.TorSharp</AssemblyName>
     <RootNamespace>Knapcode.TorSharp</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>1591</NoWarn>
+    <NoWarn>1591;S2346</NoWarn>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\TorSharp.snk</AssemblyOriginatorKeyFile>
 

--- a/src/TorSharp/TorSharp.csproj
+++ b/src/TorSharp/TorSharp.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>Knapcode.TorSharp</AssemblyName>
     <RootNamespace>Knapcode.TorSharp</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>1591;S2346</NoWarn>
+    <NoWarn>1591</NoWarn>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\TorSharp.snk</AssemblyOriginatorKeyFile>
 

--- a/src/TorSharp/TorSharp.csproj
+++ b/src/TorSharp/TorSharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(CoreOnly)' != 'true'">net462;net472;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(CoreOnly)' != 'true'">net472;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(CoreOnly)' == 'true'">netstandard2.0</TargetFrameworks>
     <AssemblyName>Knapcode.TorSharp</AssemblyName>
     <RootNamespace>Knapcode.TorSharp</RootNamespace>

--- a/src/TorSharp/TorSharpArchitecture.cs
+++ b/src/TorSharp/TorSharpArchitecture.cs
@@ -8,5 +8,6 @@
         Unknown,
         X86,
         X64,
+        Arm64
     }
 }

--- a/src/TorSharp/TorSharpArchitecture.cs
+++ b/src/TorSharp/TorSharpArchitecture.cs
@@ -1,13 +1,18 @@
-﻿namespace Knapcode.TorSharp
+﻿using System;
+
+namespace Knapcode.TorSharp
 {
     /// <summary>
     /// CPU architectures that TorSharp can run on.
     /// </summary>
+    [Flags]
     public enum TorSharpArchitecture
     {
-        Unknown,
-        X86,
-        X64,
-        Arm64
+        Unknown = 0,
+        X86 = 1,
+        X64 = 2,
+        Arm = 4,
+        Arm32 = Arm | X86,
+        Arm64 = Arm | X64
     }
 }

--- a/src/TorSharp/TorSharpArchitecture.cs
+++ b/src/TorSharp/TorSharpArchitecture.cs
@@ -1,18 +1,14 @@
-﻿using System;
-
-namespace Knapcode.TorSharp
+﻿namespace Knapcode.TorSharp
 {
     /// <summary>
     /// CPU architectures that TorSharp can run on.
     /// </summary>
-    [Flags]
     public enum TorSharpArchitecture
     {
-        Unknown = 0,
-        X86 = 1,
-        X64 = 2,
-        Arm = 4,
-        Arm32 = Arm | X86,
-        Arm64 = Arm | X64
+        Unknown,
+        X86,
+        X64,
+        Arm32,
+        Arm64
     }
 }

--- a/src/TorSharp/TorSharpPrivoxySettings.cs
+++ b/src/TorSharp/TorSharpPrivoxySettings.cs
@@ -42,5 +42,10 @@
         /// See https://www.privoxy.org/user-manual/config.html#MAX-CLIENT-CONNECTIONS for more details.
         /// </summary>
         public int? MaxClientConnections { get; set; }
+
+        /// <summary>
+        /// Automate find privoxy in system. Must be helpful for linux users when you can install privoxy from system repositorys.
+        /// </summary>
+        public bool AutomateFindInSystem { get; set; }
     }
 }

--- a/src/TorSharp/TorSharpPrivoxySettings.cs
+++ b/src/TorSharp/TorSharpPrivoxySettings.cs
@@ -44,8 +44,8 @@
         public int? MaxClientConnections { get; set; }
 
         /// <summary>
-        /// Automate find privoxy in system. Must be helpful for linux users when you can install privoxy from system repositorys.
+        /// Automatically find privoxy in the system. May be helpful for linux users when you can install privoxy from a system repository.
         /// </summary>
-        public bool AutomateFindInSystem { get; set; }
+        public bool AutomaticallyFindInSystem { get; set; }
     }
 }

--- a/src/TorSharp/TorSharpSettings.cs
+++ b/src/TorSharp/TorSharpSettings.cs
@@ -48,6 +48,9 @@ namespace Knapcode.TorSharp
                 case SystemArchitecture.X64:
                     Architecture = TorSharpArchitecture.X64;
                     break;
+                case SystemArchitecture.Arm:
+                    Architecture = TorSharpArchitecture.Arm32;
+                    break;
                 case SystemArchitecture.Arm64:
                     Architecture = TorSharpArchitecture.Arm64;
                     break;
@@ -70,7 +73,7 @@ namespace Knapcode.TorSharp
                 PrivoxySettings.AutomateFindInSystem = true;
                 TorSettings.AutomateFindInSystem = true;
             }
-            if (Architecture == TorSharpArchitecture.Arm64)
+            if (Architecture.HasFlag(TorSharpArchitecture.Arm))
             {
                 PrivoxySettings.Disable = true;
             }
@@ -190,6 +193,11 @@ namespace Knapcode.TorSharp
         /// Settings specific to Tor.
         /// </summary>
         public TorSharpTorSettings TorSettings { get; set; }
+
+        /// <summary>
+        /// Allow non official download repository.
+        /// </summary>
+        public bool AllowUnofficialSources { get; set; }
 
         [Obsolete("Use the " + nameof(TorSharpPrivoxySettings) + "." + nameof(TorSharpPrivoxySettings.Port) + " property instead.")]
         public int PrivoxyPort

--- a/src/TorSharp/TorSharpSettings.cs
+++ b/src/TorSharp/TorSharpSettings.cs
@@ -48,6 +48,9 @@ namespace Knapcode.TorSharp
                 case SystemArchitecture.X64:
                     Architecture = TorSharpArchitecture.X64;
                     break;
+                case SystemArchitecture.Arm64:
+                    Architecture = TorSharpArchitecture.Arm64;
+                    break;
                 default:
                     Architecture = TorSharpArchitecture.Unknown;
                     break;

--- a/src/TorSharp/TorSharpSettings.cs
+++ b/src/TorSharp/TorSharpSettings.cs
@@ -60,8 +60,8 @@ namespace Knapcode.TorSharp
             if (OSPlatform == TorSharpOSPlatform.Linux)
             {
                 // It's simply better for any linux distro to try find and use system binaries.
-                PrivoxySettings.AutomateFindInSystem = true;
-                TorSettings.AutomateFindInSystem = true;
+                PrivoxySettings.AutomaticallyFindInSystem = true;
+                TorSettings.AutomaticallyFindInSystem = true;
             }
             if (Architecture.HasFlag(TorSharpArchitecture.Arm))
             {

--- a/src/TorSharp/TorSharpSettings.cs
+++ b/src/TorSharp/TorSharpSettings.cs
@@ -62,6 +62,19 @@ namespace Knapcode.TorSharp
 
             PrivoxySettings = new TorSharpPrivoxySettings();
             TorSettings = new TorSharpTorSettings();
+
+#if NETSTANDARD
+            if (OSPlatform == TorSharpOSPlatform.Linux)
+            {
+                // It's simply better for any linux distro to try find and use system binaries.
+                PrivoxySettings.AutomateFindInSystem = true;
+                TorSettings.AutomateFindInSystem = true;
+            }
+            if (Architecture == TorSharpArchitecture.Arm64)
+            {
+                PrivoxySettings.Disable = true;
+            }
+#endif
         }
 
         /// <summary>

--- a/src/TorSharp/TorSharpSettings.cs
+++ b/src/TorSharp/TorSharpSettings.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Text;
+using Knapcode.TorSharp.Tools;
 #if NETSTANDARD
 using System.Runtime.InteropServices;
 using SystemOSPlatform = System.Runtime.InteropServices.OSPlatform;
@@ -63,7 +64,7 @@ namespace Knapcode.TorSharp
                 PrivoxySettings.AutomaticallyFindInSystem = true;
                 TorSettings.AutomaticallyFindInSystem = true;
             }
-            if (Architecture.HasFlag(TorSharpArchitecture.Arm))
+            if (Architecture.Contains("Arm"))
             {
                 PrivoxySettings.Disable = true;
             }

--- a/src/TorSharp/TorSharpSettings.cs
+++ b/src/TorSharp/TorSharpSettings.cs
@@ -64,7 +64,7 @@ namespace Knapcode.TorSharp
                 PrivoxySettings.AutomaticallyFindInSystem = true;
                 TorSettings.AutomaticallyFindInSystem = true;
             }
-            if (Architecture.Contains("Arm"))
+            if (Architecture.IsArm())
             {
                 PrivoxySettings.Disable = true;
             }

--- a/src/TorSharp/TorSharpSettings.cs
+++ b/src/TorSharp/TorSharpSettings.cs
@@ -40,24 +40,14 @@ namespace Knapcode.TorSharp
                 OSPlatform = TorSharpOSPlatform.Unknown;
             }
 
-            switch (RuntimeInformation.ProcessArchitecture)
+            Architecture = RuntimeInformation.ProcessArchitecture switch
             {
-                case SystemArchitecture.X86:
-                    Architecture = TorSharpArchitecture.X86;
-                    break;
-                case SystemArchitecture.X64:
-                    Architecture = TorSharpArchitecture.X64;
-                    break;
-                case SystemArchitecture.Arm:
-                    Architecture = TorSharpArchitecture.Arm32;
-                    break;
-                case SystemArchitecture.Arm64:
-                    Architecture = TorSharpArchitecture.Arm64;
-                    break;
-                default:
-                    Architecture = TorSharpArchitecture.Unknown;
-                    break;
-            }
+                SystemArchitecture.X86 => TorSharpArchitecture.X86,
+                SystemArchitecture.X64 => TorSharpArchitecture.X64,
+                SystemArchitecture.Arm => TorSharpArchitecture.Arm32,
+                SystemArchitecture.Arm64 => TorSharpArchitecture.Arm64,
+                _ => TorSharpArchitecture.Unknown,
+            };
 #else
             OSPlatform = TorSharpOSPlatform.Windows;
             Architecture = Environment.Is64BitProcess ? TorSharpArchitecture.X64 : TorSharpArchitecture.X86;
@@ -257,20 +247,14 @@ namespace Knapcode.TorSharp
 
         private TorSharpTorSettings EnsureTorSettings()
         {
-            if (TorSettings == null)
-            {
-                TorSettings = new TorSharpTorSettings();
-            }
+            TorSettings ??= new TorSharpTorSettings();
 
             return TorSettings;
         }
 
         private TorSharpPrivoxySettings EnsurePrivoxySettings()
         {
-            if (PrivoxySettings == null)
-            {
-                PrivoxySettings = new TorSharpPrivoxySettings();
-            }
+            PrivoxySettings ??= new TorSharpPrivoxySettings();
 
             return PrivoxySettings;
         }

--- a/src/TorSharp/TorSharpToolFetcher.cs
+++ b/src/TorSharp/TorSharpToolFetcher.cs
@@ -89,7 +89,7 @@ namespace Knapcode.TorSharp
             bool useExistingTools)
         {
             var latestLocal = ToolUtility.GetLatestToolOrNull(_settings, toolSettings);
-            if (useExistingTools || latestLocal?.AutomateDetected == true)
+            if (useExistingTools || latestLocal?.AutomaticallyDetected == true)
             {
                 return null;
             }

--- a/src/TorSharp/TorSharpToolFetcher.cs
+++ b/src/TorSharp/TorSharpToolFetcher.cs
@@ -50,7 +50,7 @@ namespace Knapcode.TorSharp
         /// <summary>
         /// Checks for updates of the tools and returns what is found. Inspect the
         /// <see cref="ToolUpdates.HasUpdate"/> property to determine whether updates are available. This is
-        /// determined by checking the the latest versions are already downloads to the
+        /// determined by checking the latest versions are already downloads to the
         /// <see cref="TorSharpSettings.ZippedToolsDirectory"/>.
         /// </summary>
         /// <returns>Information about whether there are tool updates.</returns>
@@ -89,7 +89,7 @@ namespace Knapcode.TorSharp
             bool useExistingTools)
         {
             var latestLocal = ToolUtility.GetLatestToolOrNull(_settings, toolSettings);
-            if (useExistingTools && latestLocal != null)
+            if (useExistingTools || latestLocal?.AutomateDetected == true)
             {
                 return null;
             }

--- a/src/TorSharp/TorSharpTorSettings.cs
+++ b/src/TorSharp/TorSharpTorSettings.cs
@@ -178,5 +178,10 @@ namespace Knapcode.TorSharp
         /// See https://2019.www.torproject.org/docs/tor-manual-dev.html.en#ORPort for more details.
         /// </summary>
         public string ORPort { get; set; }
+
+        /// <summary>
+        /// Automate find tor in system. Must be helpful for linux users when you can install tor from system repository.
+        /// </summary>
+        public bool AutomateFindInSystem { get; set; }
     }
 }

--- a/src/TorSharp/TorSharpTorSettings.cs
+++ b/src/TorSharp/TorSharpTorSettings.cs
@@ -180,8 +180,8 @@ namespace Knapcode.TorSharp
         public string ORPort { get; set; }
 
         /// <summary>
-        /// Automate find tor in system. Must be helpful for linux users when you can install tor from system repository.
+        /// Automatically find tor in the system. May be helpful for linux users when you can install tor from a system repository.
         /// </summary>
-        public bool AutomateFindInSystem { get; set; }
+        public bool AutomaticallyFindInSystem { get; set; }
     }
 }

--- a/test/PassThroughProxy/PassThroughProxy/Configurations/Rule.cs
+++ b/test/PassThroughProxy/PassThroughProxy/Configurations/Rule.cs
@@ -10,7 +10,6 @@ namespace Proxy.Configurations
             Pattern = new Regex(pattern, RegexOptions.Compiled);
         }
 
-
         public Regex Pattern { get; private set; }
 
         public ActionEnum Action { get; private set; }

--- a/test/PassThroughProxy/PassThroughProxy/Headers/HttpHeader.cs
+++ b/test/PassThroughProxy/PassThroughProxy/Headers/HttpHeader.cs
@@ -57,15 +57,12 @@ namespace Proxy.Headers
                 .TrimStart()
                 .Split(':');
 
-            switch (split.Length)
+            return split.Length switch
             {
-                case 1:
-                    return new Address(split[0], 80);
-                case 2:
-                    return new Address(split[0], int.Parse(split[1]));
-                default:
-                    throw new FormatException(string.Join(":", split));
-            }
+                1 => new Address(split[0], 80),
+                2 => new Address(split[0], int.Parse(split[1])),
+                _ => throw new FormatException(string.Join(":", split)),
+            };
         }
 
         private static long GetContentLength(IEnumerable<string> strings)

--- a/test/PassThroughProxy/PassThroughProxy/PassThroughProxy.csproj
+++ b/test/PassThroughProxy/PassThroughProxy/PassThroughProxy.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(CoreOnly)' != 'true'">net6.0;net462;net472</TargetFrameworks>
+    <TargetFrameworks Condition="'$(CoreOnly)' != 'true'">net462;net472;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(CoreOnly)' == 'true'">net6.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <RootNamespace>Proxy</RootNamespace>
     <PackageId>PassThroughProxy</PackageId>

--- a/test/TorSharp.Tests/ARM/FetcherTests.cs
+++ b/test/TorSharp.Tests/ARM/FetcherTests.cs
@@ -5,7 +5,7 @@ using Knapcode.TorSharp.Tools.Tor;
 
 using Xunit;
 
-namespace Knapcode.TorSharp.Tests.ARM64
+namespace Knapcode.TorSharp.Tests.ARM
 {
     public class FetcherTests
     {
@@ -45,22 +45,22 @@ namespace Knapcode.TorSharp.Tests.ARM64
             Assert.NotNull(result.Url);
         }
 
-        [Fact]
-        public async Task TorSharpToolFetcher_TestDownload()
-        {
-            var settings = new TorSharpSettings()
-            {
-                OSPlatform = TorSharpOSPlatform.Linux,
-                Architecture = TorSharpArchitecture.Arm64,
-                AllowUnofficialSources = true
-            };
-            settings.PrivoxySettings.Disable = true;
+        //[Fact]
+        //public async Task TorSharpToolFetcher_TestDownload()
+        //{
+        //    var settings = new TorSharpSettings()
+        //    {
+        //        OSPlatform = TorSharpOSPlatform.Linux,
+        //        Architecture = TorSharpArchitecture.Arm64,
+        //        AllowUnofficialSources = true
+        //    };
+        //    settings.PrivoxySettings.Disable = true;
 
-            var toolFetcher = new TorSharpToolFetcher(settings, HttpClient);
-            await toolFetcher.FetchAsync();
+        //    var toolFetcher = new TorSharpToolFetcher(settings, HttpClient);
+        //    await toolFetcher.FetchAsync();
 
-            var ts = new TorSharpProxy(settings);
-            await ts.ConfigureAsync();
-        }
+        //    var ts = new TorSharpProxy(settings);
+        //    await ts.ConfigureAsync();
+        //}
     }
 }

--- a/test/TorSharp.Tests/ARM/FetcherTests.cs
+++ b/test/TorSharp.Tests/ARM/FetcherTests.cs
@@ -44,5 +44,23 @@ namespace Knapcode.TorSharp.Tests.ARM64
             Assert.NotNull(result);
             Assert.NotNull(result.Url);
         }
+
+        [Fact]
+        public async Task TorSharpToolFetcher_TestDownload()
+        {
+            var settings = new TorSharpSettings()
+            {
+                OSPlatform = TorSharpOSPlatform.Linux,
+                Architecture = TorSharpArchitecture.Arm64,
+                AllowUnofficialSources = true
+            };
+            settings.PrivoxySettings.Disable = true;
+
+            var toolFetcher = new TorSharpToolFetcher(settings, HttpClient);
+            await toolFetcher.FetchAsync();
+
+            var ts = new TorSharpProxy(settings);
+            await ts.ConfigureAsync();
+        }
     }
 }

--- a/test/TorSharp.Tests/ARM64/FetcherTests.cs
+++ b/test/TorSharp.Tests/ARM64/FetcherTests.cs
@@ -1,0 +1,48 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+
+using Knapcode.TorSharp.Tools.Tor;
+
+using Xunit;
+
+namespace Knapcode.TorSharp.Tests.ARM64
+{
+    public class FetcherTests
+    {
+        private readonly HttpClient HttpClient = new HttpClient();
+
+        [Fact]
+        public async Task TorSharpToolFetcher_TestArm32()
+        {
+            var settings = new TorSharpSettings()
+            {
+                OSPlatform = TorSharpOSPlatform.Linux,
+                Architecture = TorSharpArchitecture.Arm32,
+                AllowUnofficialSources = true
+            };
+
+            var fetcher = new TorFetcher(settings, HttpClient);
+            var result = await fetcher.GetLatestAsync();
+
+            Assert.NotNull(result);
+            Assert.NotNull(result.Url);
+        }
+
+        [Fact]
+        public async Task TorSharpToolFetcher_TestArm64()
+        {
+            var settings = new TorSharpSettings()
+            {
+                OSPlatform = TorSharpOSPlatform.Linux,
+                Architecture = TorSharpArchitecture.Arm64,
+                AllowUnofficialSources = true
+            };
+
+            var fetcher = new TorFetcher(settings, HttpClient);
+            var result =  await fetcher.GetLatestAsync();
+            
+            Assert.NotNull(result);
+            Assert.NotNull(result.Url);
+        }
+    }
+}

--- a/test/TorSharp.Tests/TestAppTests.cs
+++ b/test/TorSharp.Tests/TestAppTests.cs
@@ -56,7 +56,6 @@ namespace Knapcode.TorSharp.Tests
 
         private void Execute(bool writeToConsole, ToolRunnerType toolRunnerType, string framework)
         {
-
             // build the test app
             ExecuteDotnet(
                 new[]

--- a/test/TorSharp.Tests/TorSharp.Tests.csproj
+++ b/test/TorSharp.Tests/TorSharp.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks Condition="'$(CoreOnly)' != 'true'">net462;net472;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(CoreOnly)' == 'true'">net6.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <AssemblyName>Knapcode.TorSharp.Tests</AssemblyName>
     <RootNamespace>Knapcode.TorSharp.Tests</RootNamespace>

--- a/test/TorSharp.Tests/TorSharpFetcherTests.cs
+++ b/test/TorSharp.Tests/TorSharpFetcherTests.cs
@@ -151,7 +151,7 @@ namespace Knapcode.TorSharp.Tests
 
                     foreach (var architecture in Enum.GetValues(typeof(TorSharpArchitecture)).Cast<TorSharpArchitecture>())
                     {
-                        if (architecture == TorSharpArchitecture.Unknown || architecture == TorSharpArchitecture.Arm64)
+                        if (architecture == TorSharpArchitecture.Unknown || architecture.HasFlag(TorSharpArchitecture.Arm))
                         {
                             continue;
                         }

--- a/test/TorSharp.Tests/TorSharpFetcherTests.cs
+++ b/test/TorSharp.Tests/TorSharpFetcherTests.cs
@@ -151,7 +151,7 @@ namespace Knapcode.TorSharp.Tests
 
                     foreach (var architecture in Enum.GetValues(typeof(TorSharpArchitecture)).Cast<TorSharpArchitecture>())
                     {
-                        if (architecture == TorSharpArchitecture.Unknown)
+                        if (architecture == TorSharpArchitecture.Unknown || architecture == TorSharpArchitecture.Arm64)
                         {
                             continue;
                         }

--- a/test/TorSharp.Tests/TorSharpFetcherTests.cs
+++ b/test/TorSharp.Tests/TorSharpFetcherTests.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Knapcode.TorSharp.Tests.TestSupport;
+using Knapcode.TorSharp.Tools;
+
 using xRetry;
 using Xunit;
 using Xunit.Abstractions;
@@ -151,7 +153,7 @@ namespace Knapcode.TorSharp.Tests
 
                     foreach (var architecture in Enum.GetValues(typeof(TorSharpArchitecture)).Cast<TorSharpArchitecture>())
                     {
-                        if (architecture == TorSharpArchitecture.Unknown || architecture.HasFlag(TorSharpArchitecture.Arm))
+                        if (architecture == TorSharpArchitecture.Unknown || architecture.IsArm())
                         {
                             continue;
                         }


### PR DESCRIPTION
This allow only run exists tor files (set TorSharpSettings.ZippedToolsDirectory and TorSharpSettings.UseExistingTools), because fetch and run code must be entire rewritten.
Arm version can be downloaded here https://sourceforge.net/projects/tor-browser-ports/files/ but they have different folder structure and it require to repack .tar.gz archive to get it work.

For example [tor-browser-linux-arm64-12.0.3_ALL.tar.xz](https://sourceforge.net/projects/tor-browser-ports/files/12.0.3/tor-browser-linux-arm64-12.0.3_ALL.tar.xz/download):
Tor and Data folders are located in tor-browser\Browser\TorBrowser\.
Repack example:
[tor-linux-aarch64-12.0.3.tar.gz](https://github.com/joelverhagen/TorSharp/files/10891579/tor-linux-aarch64-12.0.3.tar.gz)

Maybe create nuget package to provide repacked tar.gz archives? Or rewrite current code to support auto download (those archive size larger that x86 bundles because they contains entire browser) and different folders structure?

Tested on Radxa Rock-5B board.
```C#
var settings = new TorSharpSettings
{
    PrivoxySettings = { Disable = true }
};

using var httpClient = new HttpClient();
if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
{
    settings.ZippedToolsDirectory = Path.Combine(AppContext.BaseDirectory, "Tor");
    settings.UseExistingTools = true;
}
else
{
    var fetcher = new TorSharpToolFetcher(settings, httpClient);
    await fetcher.FetchAsync();
}

TorProxy = new TorSharpProxy(settings);
await TorProxy.ConfigureAndStartAsync();

var handler = new HttpClientHandler
{
    Proxy = new WebProxy(new Uri("socks5://localhost:" + settings.TorSettings.SocksPort))
};
HttpClient = new HttpClient(handler)
{
    Timeout = TimeSpan.FromSeconds(300)
};
HttpClient.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36");
```